### PR TITLE
Fixed a page crashed error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.idea
 /node_modules
 /out
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -45,8 +45,6 @@ class GitbookPrinter {
     async _downloadChapterList() {
 
         /* Open browser. */
-        /* I'm not sure how helpful these changes are in the long run, but personally it seems to work (for now)... */
-        /* https://github.com/puppeteer/puppeteer/issues/3709#issuecomment-452188987 */
         const browser = await puppeteer.launch(
         {
         ignoreHTTPSErrors: true,
@@ -60,9 +58,9 @@ class GitbookPrinter {
         ]
         });
 
-
         const page = await browser.newPage();
-
+        await page.setDefaultNavigationTimeout(0); 
+        
         /* Get chapters list from summary. */
         const chapterPathList = await this._getChapterPathList();
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,8 @@ class GitbookPrinter {
     async _downloadChapterList() {
 
         /* Open browser. */
-        const browser = await puppeteer.launch();
+        const browser = await puppeteer.launch({args: ['--disable-dev-shm-usage', '--disable-gpu']});
+
 
         const page = await browser.newPage();
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,20 @@ class GitbookPrinter {
     async _downloadChapterList() {
 
         /* Open browser. */
-        const browser = await puppeteer.launch({args: ['--disable-dev-shm-usage', '--disable-gpu']});
+        /* I'm not sure how helpful these changes are in the long run, but personally it seems to work (for now)... */
+        /* https://github.com/puppeteer/puppeteer/issues/3709#issuecomment-452188987 */
+        const browser = await puppeteer.launch(
+        {
+        ignoreHTTPSErrors: true,
+        args :[
+        '--ignore-certificate-errors',
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--lang=ja,en-US;q=0.9,en;q=0.8',
+        '--user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 Safari/537.36'
+        ]
+        });
 
 
         const page = await browser.newPage();

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
   },
   "dependencies": {
     "add-zero": "^1.0.0",
-    "commander": "^2.15.1",
+    "commander": "^2.20.3",
     "easy-pdf-merge": "^0.1.3",
-    "puppeteer": "^1.4.0",
-    "rimraf": "^2.6.2"
+    "puppeteer": "^1.20.0",
+    "rimraf": "^2.7.1"
   },
   "devDependencies": {
     "standard-version": "^4.4.0"


### PR DESCRIPTION
Added '--disable-dev-shm-usage', '--disable-gpu'  into the puppeteer launch in order to fix a "(node:117132) UnhandledPromiseRejectionWarning: Error: Page crashed!" error I was constantly getting. 

Thank you to https://github.com/puppeteer/puppeteer/issues/1321#issuecomment-530758299 for the fix aha! 
I have no knowledge of Javascript/Node but this seems to work for me so I would like to see if this helps others too.